### PR TITLE
[Resolves] #2 - Incorrect page numbers

### DIFF
--- a/src/scraping.rs
+++ b/src/scraping.rs
@@ -26,7 +26,7 @@ pub fn torrent_search(s: &str) -> Result<Vec<Torrent>, Error> {
 
     let mut all_the_torrents = vec![];
 
-    for n in 0.. {
+    for n in 1.. {
         let mut torrents = torrent_search_page(&client, s, n)?;
         if torrents.is_empty() {
             break;


### PR DESCRIPTION
This PR fixes the problem that the incorrect index is used, resulting in duplicate records being returned.