### PR TITLE
[Resolves] #3 - Infinite loop when searching for torrents

### DIFF
--- a/src/scraping.rs
+++ b/src/scraping.rs
@@ -26,9 +26,11 @@ pub fn torrent_search(s: &str) -> Result<Vec<Torrent>, Error> {
 
     let mut all_the_torrents = vec![];
 
-    for n in 0.. {
+    for n in 1.. {
         let mut torrents = torrent_search_page(&client, s, n)?;
         if torrents.is_empty() {
+            break;
+        } else if all_the_torrents.iter().last() == torrents.last() {
             break;
         } else {
             all_the_torrents.append(&mut torrents);

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,5 +1,5 @@
 /// Struct that represents a torrent and contains some of its basic information.
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub struct Torrent {
     /// The category of the torrent.
     pub category: Category,
@@ -46,7 +46,7 @@ impl Torrent {
 
         None
     }
-    
+
     /// Extract magnet link as `String`.
     pub fn magnet_link(&self) -> Option<String> {
         let (first, second) = &self.links;
@@ -68,7 +68,7 @@ impl Torrent {
 }
 
 /// Enum that encodes a torrent's category.
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum Category {
     Anime(Anime),
     Audio(Audio),
@@ -79,7 +79,7 @@ pub enum Category {
 }
 
 /// Enum that encodes variants of anime torrents.
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum Anime {
     AnimeMusicVideo,
     EnglishTranslated,
@@ -88,14 +88,14 @@ pub enum Anime {
 }
 
 /// Enum that encodes variants of audio torrents.
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum Audio {
     Lossless,
     Lossy,
 }
 
 /// Enum that encodes variants of literature torrents.
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum Literature {
     EnglishTranslated,
     NonEnglishTranslated,
@@ -103,7 +103,7 @@ pub enum Literature {
 }
 
 /// Enum that encodes variants of live action torrents.
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum LiveAction {
     EnglishTranslated,
     IdolPromotionalVideo,
@@ -112,21 +112,21 @@ pub enum LiveAction {
 }
 
 /// Enum that encodes variants of pictures torrents.
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum Pictures {
     Graphics,
     Photos,
 }
 
 /// Enum that encodes variants of software torrents.
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum Software {
     Applications,
     Games,
 }
 
 /// Emun that encodes possible errors
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum Error {
     /// Error with the request e.g. the server do not respond or you don't have
     /// access to it.


### PR DESCRIPTION
This PR fixes an bug resulting in an infinite loop when searching for torrents by comparing the last items in the list all_the_torrents and torrents.